### PR TITLE
Adding the missing govuk_frontend.js file

### DIFF
--- a/source/javascripts/govuk_frontend.js
+++ b/source/javascripts/govuk_frontend.js
@@ -1,0 +1,1 @@
+//= require govuk_frontend_all


### PR DESCRIPTION
For this change was necessary the following steps: 
  - create a `govuk_frontend.js` file your project’s `source/assets/javascripts` directory
  - add `//= require govuk_frontend_all` into it